### PR TITLE
Add “25th Anniversary Hub” to VSD’s menu & nav

### DIFF
--- a/sites/vision-systems.com/config/navigation.js
+++ b/sites/vision-systems.com/config/navigation.js
@@ -8,6 +8,7 @@ module.exports = {
       { href: '/cameras-accessories', label: 'Cameras and Accessories' },
       { href: '/boards-software', label: 'Boards and Software' },
       { href: '/embedded', label: 'Embedded Vision' },
+      { href: '/vision-systems-design-25-year-anniversary', label: '25th Anniversary Hub' },
     ],
   },
   secondary: {
@@ -45,6 +46,7 @@ module.exports = {
         { href: '/cameras-accessories', label: 'Cameras and Accessories' },
         { href: '/boards-software', label: 'Boards and Software' },
         { href: '/embedded', label: 'Embedded Vision' },
+        { href: '/vision-systems-design-25-year-anniversary', label: '25th Anniversary Hub' },
       ],
     },
     {


### PR DESCRIPTION
Not to go live before Jan 1
https://southcomm.atlassian.net/browse/DEV-388

<img width="1754" alt="Screen Shot 2020-12-08 at 2 35 24 PM" src="https://user-images.githubusercontent.com/12496550/101538552-e797de00-3962-11eb-85a7-b183bf60877e.png">
