### PR TITLE
Officer Video page updates

### DIFF
--- a/sites/officer.com/config/gam.js
+++ b/sites/officer.com/config/gam.js
@@ -330,6 +330,24 @@ config
     { name: 'load-more', templateName: 'LM', path: 'vehicles-fleet/vehicles-equipment/load-more' },
     { name: 'reskin', path: 'vehicles-fleet/vehicles-equipment/reskin' },
     { name: 'wa', path: 'vehicles-fleet/vehicles-equipment/wa' },
+  ])
+  .setAliasAdUnits('videos', [
+    { name: 'lb1', templateName: 'LB1', path: 'videos/lb1' },
+    { name: 'lb2', templateName: 'LB2', path: 'videos/lb2' },
+    { name: 'rail1', templateName: 'RAIL1', path: 'videos/rail1' },
+    { name: 'rail2', templateName: 'RAIL2', path: 'videos/rail2' },
+    { name: 'load-more', templateName: 'LM', path: 'videos/load-more' },
+    { name: 'reskin', path: 'videos/reskin' },
+    { name: 'wa', path: 'videos/wa' },
+  ])
+  .setAliasAdUnits('media-center/video', [
+    { name: 'lb1', templateName: 'LB1', path: 'media-center/video/lb1' },
+    { name: 'lb2', templateName: 'LB2', path: 'media-center/video/lb2' },
+    { name: 'rail1', templateName: 'RAIL1', path: 'media-center/video/rail1' },
+    { name: 'rail2', templateName: 'RAIL2', path: 'media-center/video/rail2' },
+    { name: 'load-more', templateName: 'LM', path: 'media-center/video/load-more' },
+    { name: 'reskin', path: 'media-center/video/reskin' },
+    { name: 'wa', path: 'media-center/video/wa' },
   ]);
 
 module.exports = config;

--- a/sites/officer.com/config/gam.js
+++ b/sites/officer.com/config/gam.js
@@ -331,15 +331,6 @@ config
     { name: 'reskin', path: 'vehicles-fleet/vehicles-equipment/reskin' },
     { name: 'wa', path: 'vehicles-fleet/vehicles-equipment/wa' },
   ])
-  .setAliasAdUnits('videos', [
-    { name: 'lb1', templateName: 'LB1', path: 'videos/lb1' },
-    { name: 'lb2', templateName: 'LB2', path: 'videos/lb2' },
-    { name: 'rail1', templateName: 'RAIL1', path: 'videos/rail1' },
-    { name: 'rail2', templateName: 'RAIL2', path: 'videos/rail2' },
-    { name: 'load-more', templateName: 'LM', path: 'videos/load-more' },
-    { name: 'reskin', path: 'videos/reskin' },
-    { name: 'wa', path: 'videos/wa' },
-  ])
   .setAliasAdUnits('media-center/video', [
     { name: 'lb1', templateName: 'LB1', path: 'media-center/video/lb1' },
     { name: 'lb2', templateName: 'LB2', path: 'media-center/video/lb2' },

--- a/sites/officer.com/config/navigation.js
+++ b/sites/officer.com/config/navigation.js
@@ -65,7 +65,7 @@ module.exports = {
         { href: '/careers', label: 'Careers' },
         { href: '/events', label: 'Events' },
         { href: '/federal', label: 'Federal' },
-        { href: '/videos', label: 'Videos' },
+        { href: '/media-center/video', label: 'Videos' },
       ],
     },
     {

--- a/sites/officer.com/server/routes/published-content.js
+++ b/sites/officer.com/server/routes/published-content.js
@@ -1,9 +1,7 @@
 const webinars = require('@endeavor-business-media/package-shared/templates/published-content/webinars');
 const events = require('@endeavor-business-media/package-shared/templates/published-content/events');
-const videos = require('@endeavor-business-media/package-shared/templates/published-content/videos');
 
 module.exports = (app) => {
   app.get('/events', (_, res) => { res.marko(events); });
   app.get('/webinars', (_, res) => { res.marko(webinars, { title: 'Webinars' }); });
-  app.get('/videos', (_, res) => { res.marko(videos); });
 };


### PR DESCRIPTION
https://southcomm.atlassian.net/browse/DEV-371
waiting on confirmation that in order to add a GAM alias to /videos, they'll need to switch to manual scheduling, instead of the page automatically pulling all published Videos.  Also inquired as to how the Videos block on the homepage should function pending how we handle the /videos page.

<img width="1608" alt="Screen Shot 2020-12-08 at 2 48 29 PM" src="https://user-images.githubusercontent.com/12496550/101541072-7d813800-3966-11eb-944f-ed4e18868b40.png">
