### PR TITLE
Updated navs and logo for VSP

### DIFF
--- a/sites/vehicleservicepros.com/config/navigation.js
+++ b/sites/vehicleservicepros.com/config/navigation.js
@@ -14,13 +14,12 @@ module.exports = {
   },
   secondary: {
     items: [
-      { href: 'http://www.cdsreportnow.com/GET/INFO?PTEN', label: 'PTEN E-Inquiry', target: '_blank' },
-      { href: 'http://www.cdsreportnow.com/GET/INFO?PRD', label: 'PD E-Inquiry', target: '_blank' },
-      { href: '/magazine', label: 'In Print' },
-      { href: '/page/advertise', label: 'Advertise' },
-      { href: '/contact-us', label: 'Contact Us' },
-      { href: '/subscribe', label: 'Subscribe' },
-      { href: 'https://vehicleservicepros.jobboard.io', label: 'Job Board', target: '_blank' },
+      { href: '/magazine/53cd1d791784f8066eb2ca77', label: 'PTEN' },
+      { href: '/magazine/5fd243a354604646568b4699', label: 'Motor Age' },
+      { href: '/magazine/5fd24441f33eacc64f8b46ea', label: 'ABRN' },
+      { href: '/magazine/53cd1d791784f8066eb2ca78', label: 'Professional Distributor' },
+      { href: '/distribution', label: 'AMBW' },
+      { href: 'https://passthease.motoragetraining.com/content/Motor-Age-Training.aspx', label: 'Motor Age Training', target: '_blank' },
     ],
   },
   tertiary: {
@@ -43,7 +42,7 @@ module.exports = {
       label: 'Topics',
       items: [
         { label: 'Service Repair', href: '/service-repair' },
-        { label: 'Diagnostics and Drivability', href: '/industry-news/service-repair' },
+        { label: 'Diagnostics and Drivability', href: '/service-repair/diagnostics-and-drivability' },
         { label: 'Underhood', href: '/service-repair/underhood' },
         { label: 'Undercar', href: '/service-repair/undercar' },
         { label: 'Battery and Electrical', href: '/service-repair/battery-and-electrical' },

--- a/sites/vehicleservicepros.com/config/site.js
+++ b/sites/vehicleservicepros.com/config/site.js
@@ -1,8 +1,8 @@
 const navigation = require('./navigation');
 const gam = require('./gam');
-
 const nativeX = require('./native-x');
 const dragonForms = require('./dragon-forms');
+
 const siteLogo = 'https://img.vehicleservicepros.com/files/base/cygnus/vspc/image/static/logo/vsp.png?h=60';
 
 module.exports = {

--- a/sites/vehicleservicepros.com/config/site.js
+++ b/sites/vehicleservicepros.com/config/site.js
@@ -1,8 +1,8 @@
 const navigation = require('./navigation');
 const gam = require('./gam');
-
 const nativeX = require('./native-x');
 const dragonForms = require('./dragon-forms');
+const siteLogo = 'https://img.vehicleservicepros.com/files/base/cygnus/vspc/image/static/logo/vsp.png?h=60';
 
 module.exports = {
   navigation,
@@ -12,15 +12,15 @@ module.exports = {
   company: 'Endeavor Business Media, LLC',
   logos: {
     navbar: {
-      src: 'https://img.vehicleservicepros.com/files/base/cygnus/vspc/image/static/logo/VSP_header_logos_V2.png?h=60',
+      src: siteLogo,
       srcset: [
-        'https://img.vehicleservicepros.com/files/base/cygnus/vspc/image/static/logo/VSP_header_logos_V2.png?h=120 2x',
+        'https://img.vehicleservicepros.com/files/base/cygnus/vspc/image/static/logo/vsp.png?h=120 2x',
       ],
     },
     footer: {
-      src: 'https://img.vehicleservicepros.com/files/base/cygnus/vspc/image/static/logo/VSP_header_logos_V2.png?h=60',
+      src: siteLogo,
       srcset: [
-        'https://img.vehicleservicepros.com/files/base/cygnus/vspc/image/static/logo/VSP_header_logos_V2.png?h=120 2x',
+        'https://img.vehicleservicepros.com/files/base/cygnus/vspc/image/static/logo/vsp.png?h=120 2x',
       ],
     },
   },
@@ -59,7 +59,7 @@ module.exports = {
   contactUs: {
     branding: {
       bgColor: '#164f77',
-      logo: 'https://img.vehicleservicepros.com/files/base/cygnus/vspc/image/static/logo/vsp.png?h=60',
+      logo: siteLogo,
     },
     to: 'contact@vehicleservicepros.com',
   },
@@ -69,7 +69,7 @@ module.exports = {
     sendTo: 'sales@vehicleservicepros.com',
     sendFrom: 'VehicleServicePros.com <noreply@baseplatform.io>',
     sendBcc: 'eactivity@endeavorb2b.com',
-    logo: 'https://img.vehicleservicepros.com/files/base/cygnus/vspc/image/static/logo/vsp.png?h=60',
+    logo: siteLogo,
     bgColor: '#164f77',
   },
 };

--- a/sites/vehicleservicepros.com/config/site.js
+++ b/sites/vehicleservicepros.com/config/site.js
@@ -1,5 +1,6 @@
 const navigation = require('./navigation');
 const gam = require('./gam');
+
 const nativeX = require('./native-x');
 const dragonForms = require('./dragon-forms');
 const siteLogo = 'https://img.vehicleservicepros.com/files/base/cygnus/vspc/image/static/logo/vsp.png?h=60';


### PR DESCRIPTION
Per https://southcomm.atlassian.net/browse/DEV-410

Reversed it back to the regular logo, updated the secondary nav to include the sub-magazines, and updated the url for a hamburger nav item.

<img width="949" alt="Screen Shot 2020-12-16 at 11 23 29 AM" src="https://user-images.githubusercontent.com/6343242/102377676-f1d56000-3f92-11eb-9b97-e45dec0fb46d.png">

<img width="425" alt="Screen Shot 2020-12-16 at 11 24 26 AM" src="https://user-images.githubusercontent.com/6343242/102377638-e84bf800-3f92-11eb-81ee-f23cdb1bc955.png">
