### PR TITLE
Correct pub code in “Leaders” logo file path

### DIFF
--- a/sites/cablinginstall.com/config/leaders.js
+++ b/sites/cablinginstall.com/config/leaders.js
@@ -3,6 +3,6 @@ module.exports = {
   alias: 'leaders/2020',
   calloutValue: 'Leading Companies',
   header: {
-    imgSrc: 'https://img.cablinginstall.com/files/base/ebm/diq/image/static/CIM_Leaders.png?h=90',
+    imgSrc: 'https://img.cablinginstall.com/files/base/ebm/cim/image/static/CIM_Leaders.png?h=90',
   },
 };

--- a/sites/officer.com/config/leaders.js
+++ b/sites/officer.com/config/leaders.js
@@ -3,6 +3,6 @@ module.exports = {
   alias: 'leaders/2020',
   calloutValue: 'Leading Companies',
   header: {
-    imgSrc: 'https://img.officer.com/files/base/cygnus/ofcr/image/static/leaders in law enforcement with badge.png?h=90',
+    imgSrc: 'https://img.officer.com/files/base/cygnus/ofcr/image/static/officer-leaders.png?h=90',
   },
 };


### PR DESCRIPTION
Already uploaded to s3, so it should switch over to the new logo automatically when this goes live.