### PR TITLE
Override filter on logo for PI

### DIFF
--- a/sites/piprocessinstrumentation.com/server/styles/index.scss
+++ b/sites/piprocessinstrumentation.com/server/styles/index.scss
@@ -27,6 +27,9 @@ $theme-site-navbar-logo-height-sm: 25px;
 $theme-newsletter-block-bg-color: $primary;
 $theme-newsletter-block-button-bg-color: #000;
 
+$theme-site-navbar-logo-drop-shadow: "";
+$theme-site-footer-logo-box-shadow: "";
+
 $theme-site-header-breakpoints: (
   hide-primary: 1005px,
   hide-secondary: 906px,
@@ -37,9 +40,3 @@ $theme-site-header-breakpoints: (
 
 @import "../../node_modules/@endeavor-business-media/package-shared/scss/core";
 @import "../../node_modules/@endeavor-business-media/package-common/scss/algolia";
-
-.site-navbar {
-  &__logo {
-    filter: none;
-  }
-}

--- a/sites/piprocessinstrumentation.com/server/styles/index.scss
+++ b/sites/piprocessinstrumentation.com/server/styles/index.scss
@@ -37,3 +37,9 @@ $theme-site-header-breakpoints: (
 
 @import "../../node_modules/@endeavor-business-media/package-shared/scss/core";
 @import "../../node_modules/@endeavor-business-media/package-common/scss/algolia";
+
+.site-navbar {
+  &__logo {
+    filter: none;
+  }
+}


### PR DESCRIPTION
Remove filter shading from PI logo

Before:
<img width="260" alt="Screen Shot 2020-12-29 at 11 59 21 AM" src="https://user-images.githubusercontent.com/6343242/103300686-7382b000-49cd-11eb-92ab-6f48b8773f4e.png">

After:
<img width="254" alt="Screen Shot 2020-12-29 at 11 59 13 AM" src="https://user-images.githubusercontent.com/6343242/103300700-7a112780-49cd-11eb-952d-d3a7a49c63f9.png">
