### PR TITLE
Remove ads from whitepapers

### DIFF
--- a/packages/shared/components/document.marko
+++ b/packages/shared/components/document.marko
@@ -1,3 +1,4 @@
+$ const { type } = input;
 $ const {
   site,
   req,
@@ -5,10 +6,11 @@ $ const {
   GAM,
 } = out.global;
 
+$ const contentType = input.container.page.type;
 $ const prestitial = GAM ? GAM.getAdUnit({ name: "wa" }) : {};
 $ const hasPrestitial = Boolean(prestitial.path);
-$ const wrapperStyle = hasPrestitial ? "opacity: 0;" : null;
-
+$ const displayPrestitial = hasPrestitial && contentType !== "whitepaper";
+$ const wrapperStyle = displayPrestitial ? "opacity: 0;" : null;
 $ const radix = site.getAsObject("radix");
 $ const isRadixEnabled = Boolean(radix.enabled && radix.appId);
 
@@ -25,7 +27,7 @@ $ const isRadixEnabled = Boolean(radix.enabled && radix.appId);
     <if(nativeX)>
       <marko-web-native-x-init uri=nativeX.getUri() enabled=nativeX.isEnabled() />
     </if>
-    <if(hasPrestitial)>
+    <if(displayPrestitial)>
       <gam-prestitial init=true adunit=prestitial />
     </if>
     <${input.head} />
@@ -40,7 +42,7 @@ $ const isRadixEnabled = Boolean(radix.enabled && radix.appId);
   <@body-wrapper enabled=true attrs={ id: "body-wrapper", style: wrapperStyle } />
   <@above-wrapper>
     <leaders-dropdown-portal />
-    <if(hasPrestitial)>
+    <if(displayPrestitial)>
       <gam-prestitial display=true adunit=prestitial />
     </if>
   </@above-wrapper>

--- a/sites/strategies-u.com/server/templates/website-section/white-papers.marko
+++ b/sites/strategies-u.com/server/templates/website-section/white-papers.marko
@@ -24,7 +24,6 @@ $ const description = "The latest white papers from Strategies Unlimited";
   <@above-container>
     <marko-web-resolve-page|{ data: section }| node=pageNode>
       $ const aliases = hierarchyAliases(section);
-      <marko-web-gam-out-of-page-ad ...GAM.getAdUnit({ name: "wa", aliases }) />
       <marko-web-gam-out-of-page-ad ...GAM.getAdUnit({ name: "reskin", aliases }) />
     </marko-web-resolve-page>
   </@above-container>


### PR DESCRIPTION
Checks for content type before displaying prestitial ads, doesn't display on whitepapers

Relates to: https://southcomm.atlassian.net/browse/DEV-443