### PR TITLE
Officer: Responsive header updates

### DIFF
--- a/sites/officer.com/server/styles/index.scss
+++ b/sites/officer.com/server/styles/index.scss
@@ -25,7 +25,8 @@ $theme-newsletter-block-button-bg-color: #000;
 $theme-site-header-breakpoints: (
   hide-primary: 832px,
   hide-secondary: 906px,
-  small-logo: 1015px,
+  hide-tertiary: 400px,
+  small-logo: 1235px,
   small-text-primary: 932px,
   small-text-secondary: 1105px
 );
@@ -38,5 +39,20 @@ $theme-site-header-breakpoints: (
     max-width: 300px;
     margin-right: auto;
     margin-left: auto;
+  }
+}
+
+// Add x-small logo and menu settings for phones
+@media (max-width: 500px) {
+  .site-navbar {
+    &__logo {
+      height: 15px;
+    }
+    &__items {
+      &--tertiary {
+        padding-left: .5em;
+        margin-left: .5em;
+      }
+    }
   }
 }

--- a/sites/officer.com/server/styles/index.scss
+++ b/sites/officer.com/server/styles/index.scss
@@ -48,11 +48,5 @@ $theme-site-header-breakpoints: (
     &__logo {
       height: 15px;
     }
-    &__items {
-      &--tertiary {
-        padding-left: .5em;
-        margin-left: .5em;
-      }
-    }
   }
 }


### PR DESCRIPTION
Bug fix caused by logo change from last release

Current:
<img width="1110" alt="Screen Shot 2021-01-29 at 12 43 27 PM" src="https://user-images.githubusercontent.com/6343242/106309094-a5d33780-622f-11eb-87e8-86775fdac92c.png">
<img width="555" alt="Screen Shot 2021-01-29 at 12 44 27 PM" src="https://user-images.githubusercontent.com/6343242/106309379-06627480-6230-11eb-9751-9a48eb654893.png">



New:
<img width="1145" alt="Screen Shot 2021-01-29 at 12 43 36 PM" src="https://user-images.githubusercontent.com/6343242/106309106-a966be80-622f-11eb-9636-359bcb6c1afc.png">
<img width="552" alt="Screen Shot 2021-01-29 at 12 46 25 PM" src="https://user-images.githubusercontent.com/6343242/106309395-0a8e9200-6230-11eb-9a09-d46fbe3ac13b.png">
