### PR TITLE
Subscribe page updates for CIM and BTR

### DIFF
--- a/sites/broadbandtechreport.com/config/dragon-forms.js
+++ b/sites/broadbandtechreport.com/config/dragon-forms.js
@@ -4,6 +4,8 @@ const config = new DragonFormsConfig({ url: 'https://endeavor.dragonforms.com' }
 
 config
   .addForm('doNotSell', { omedasite: 'EBM_DoNotSell' })
+  .addForm('newsletterSubscribe', { omedasite: 'BTRnewpref' })
+  .addForm('newsletterManage', { omedasite: 'BTRPrefPage' })
   .addForm('newsletterSignup', { omedasite: 'BTRnewpref', query: { pk: 'ARTWEB' } });
 
 module.exports = config;

--- a/sites/broadbandtechreport.com/server/templates/subscribe/index.marko
+++ b/sites/broadbandtechreport.com/server/templates/subscribe/index.marko
@@ -9,14 +9,31 @@ $ const dragonForms = require('../../../config/dragon-forms');
       <div class="col">
         <h4>Newsletters</h4>
         <p>Stay up-to-date on industry news and events, new product launches and more. Select from our list of targeted email offerings to stay informed on the topics that matter to you and your business.</p>
-        <p>
-          <marko-web-link
-            class="font-weight-bold"
-            href=dragonForms.getFormUrl('newsletterSignup')
-            target="_blank">
-            Subscribe / Manage Preferences
-          </marko-web-link>
-        </p>
+        <div class="row">
+          <div class="col">
+            <h5>Subscribe to:</h5>
+            <p>
+              <marko-web-link
+                class="font-weight-bold"
+                href=dragonForms.getFormUrl('newsletterSubscribe')
+                target="_blank">
+                Broadband Technology Report
+              </marko-web-link>
+            </p>
+          </div>
+          <div class="col">
+            <h5>Manage:</h5>
+            <p class="btn btn-sm btn-outline-primary">
+              <marko-web-link
+                class="font-weight-bold"
+                href=dragonForms.getFormUrl('newsletterManage')
+                target="_blank">
+                Newsletter Preferences
+              </marko-web-link>
+            </p>
+          </div>
+
+        </div>
         <hr>
       </div>
     </div>

--- a/sites/cablinginstall.com/config/dragon-forms.js
+++ b/sites/cablinginstall.com/config/dragon-forms.js
@@ -4,6 +4,8 @@ const config = new DragonFormsConfig({ url: 'https://endeavor.dragonforms.com' }
 
 config
   .addForm('doNotSell', { omedasite: 'EBM_DoNotSell' })
-  .addForm('newsletterSignup', { omedasite: 'CIMNewPref', query: { pk: 'ARTWEB' } });
+  .addForm('newsletterSubscribe', { omedasite: 'CIMNewpref' })
+  .addForm('newsletterManage', { omedasite: 'CIMPrefPage' })
+  .addForm('newsletterSignup', { omedasite: 'CIMNewpref', query: { pk: 'ARTWEB' } });
 
 module.exports = config;

--- a/sites/cablinginstall.com/server/templates/subscribe/index.marko
+++ b/sites/cablinginstall.com/server/templates/subscribe/index.marko
@@ -4,23 +4,42 @@ $ const dragonForms = require('../../../config/dragon-forms');
 <shared-subscribe-page-layout
   description=`${config.siteName()} has products that deliver powerful content to you in a variety of forms including print, online, email and social media. To subscribe to a product or manage your current subscription, click below and put the power of ${config.siteName()} at your fingertips.`
 >
+
   <@newsletter-section>
     <div class="row">
       <div class="col">
         <h4>Newsletters</h4>
         <p>Stay up-to-date on industry news and events, new product launches and more. Select from our list of targeted email offerings to stay informed on the topics that matter to you and your business.</p>
-        <p>
-          <marko-web-link
-            class="font-weight-bold"
-            href=dragonForms.getFormUrl('newsletterSignup')
-            target="_blank">
-            Subscribe / Manage Preferences
-          </marko-web-link>
-        </p>
+        <div class="row">
+          <div class="col">
+            <h5>Subscribe to:</h5>
+            <p>
+              <marko-web-link
+                class="font-weight-bold"
+                href=dragonForms.getFormUrl('newsletterSubscribe')
+                target="_blank">
+                Cabling Installation & Maintenance
+              </marko-web-link>
+            </p>
+          </div>
+          <div class="col">
+            <h5>Manage:</h5>
+            <p class="btn btn-sm btn-outline-primary">
+              <marko-web-link
+                class="font-weight-bold"
+                href=dragonForms.getFormUrl('newsletterManage')
+                target="_blank">
+                Newsletter Preferences
+              </marko-web-link>
+            </p>
+          </div>
+
+        </div>
         <hr>
       </div>
     </div>
   </@newsletter-section>
+
   <@magazine-section>
     <div class="row">
       <div class="col mb-block">


### PR DESCRIPTION
Per https://southcomm.atlassian.net/browse/DEV-481

On BTR (https://www.broadbandtechreport.com/subscribe), please break out the "Subscribe" & "Manage Preferences" links so they site on their own line. Please update the links to point to
Subscribe – https://endeavor.dragonforms.com/loading.do?omedasite=BTRnewpref
Manage Preferences - https://endeavor.dragonforms.com/loading.do?omedasite=BTRPrefPage

On CIM (https://www.cablinginstall.com/subscribe), please break out the "Subscribe" & "Manage Preferences" links so they site on their own line. Please update the links to point to
 Subscribe –https://endeavor.dragonforms.com/loading.do?omedasite=CIMNewPref
Manage Preferences - https://endeavor.dragonforms.com/loading.do?omedasite=CIMPrefPage

![Screen Shot 2021-02-11 at 1 07 27 PM](https://user-images.githubusercontent.com/6343242/107679457-95c54a00-6c6a-11eb-9b52-11ec8d0a067d.png)

![Screen Shot 2021-02-11 at 1 11 14 PM](https://user-images.githubusercontent.com/6343242/107679497-a37acf80-6c6a-11eb-9927-214061940034.png)
