### PR TITLE
Updates to TPA’s subscribe page

### DIFF
--- a/sites/taxpracticeadvisor.com/config/dragon-forms.js
+++ b/sites/taxpracticeadvisor.com/config/dragon-forms.js
@@ -4,8 +4,8 @@ const config = new DragonFormsConfig({ url: 'https://endeavor.dragonforms.com' }
 
 config
   .addForm('doNotSell', { omedasite: 'EBM_DoNotSell' })
-  .addForm('newsletterSignup', { omedasite: 'CPAnewpref', query: { pk: 'ARTWEB' } })
-  .addForm('newsletterSubscribe', { omedasite: 'CPAnewpref' })
-  .addForm('newsletterManage', { omedasite: 'CPAprefpage' });
+  .addForm('newsletterSignup', { omedasite: 'TPAnewpref', query: { pk: 'ARTWEB' } })
+  .addForm('newsletterSubscribe', { omedasite: 'TPAnewpref' })
+  .addForm('newsletterManage', { omedasite: 'TPAprefpage' });
 
 module.exports = config;

--- a/sites/taxpracticeadvisor.com/server/templates/subscribe/index.marko
+++ b/sites/taxpracticeadvisor.com/server/templates/subscribe/index.marko
@@ -1,4 +1,5 @@
 $ const { config } = out.global;
+$ const dragonForms = require('../../../config/dragon-forms');
 
 <shared-subscribe-page-layout
   description=`${config.siteName()} delivers power content to tax providers with this website and also our weekly newsletter. To subscribe or manage your current subscription, please click below and put the power of ${config.siteName()} at your fingertips.`
@@ -6,16 +7,41 @@ $ const { config } = out.global;
   <@newsletter-section>
     <div class="row">
       <div class="col">
-        <h4>Newsletter</h4>
-        <p>Stay up-to-date on news relating to tax preparers, new product launches, and more.</p>
+        <h4>Newsletters</h4>
+        <p>Stay up-to-date on industry news and events, new product launches and more. Select from our list of targeted email offerings to stay informed on the topics that matter to you and your business.</p>
         <p>
           <marko-web-link
             class="font-weight-bold"
-            href="http://cygnuscorporate.wufoo.com/forms/m1mu6gxu02je8ro/"
+            href=dragonForms.getFormUrl('newsletterSignup')
             target="_blank">
             Subscribe / Manage Preferences
           </marko-web-link>
         </p>
+        <div class="row">
+          <div class="col">
+            <h5>Subscribe to:</h5>
+            <p>
+              <marko-web-link
+                class="font-weight-bold"
+                href=dragonForms.getFormUrl('newsletterSubscribe')
+                target="_blank">
+                Broadband Technology Report
+              </marko-web-link>
+            </p>
+          </div>
+          <div class="col">
+            <h5>Manage:</h5>
+            <p class="btn btn-sm btn-outline-primary">
+              <marko-web-link
+                class="font-weight-bold"
+                href=dragonForms.getFormUrl('newsletterManage')
+                target="_blank">
+                Newsletter Preferences
+              </marko-web-link>
+            </p>
+          </div>
+
+        </div>
         <hr>
       </div>
     </div>

--- a/sites/taxpracticeadvisor.com/server/templates/subscribe/index.marko
+++ b/sites/taxpracticeadvisor.com/server/templates/subscribe/index.marko
@@ -9,14 +9,6 @@ $ const dragonForms = require('../../../config/dragon-forms');
       <div class="col">
         <h4>Newsletters</h4>
         <p>Stay up-to-date on industry news and events, new product launches and more. Select from our list of targeted email offerings to stay informed on the topics that matter to you and your business.</p>
-        <p>
-          <marko-web-link
-            class="font-weight-bold"
-            href=dragonForms.getFormUrl('newsletterSignup')
-            target="_blank">
-            Subscribe / Manage Preferences
-          </marko-web-link>
-        </p>
         <div class="row">
           <div class="col">
             <h5>Subscribe to:</h5>
@@ -25,7 +17,7 @@ $ const dragonForms = require('../../../config/dragon-forms');
                 class="font-weight-bold"
                 href=dragonForms.getFormUrl('newsletterSubscribe')
                 target="_blank">
-                Broadband Technology Report
+                Tax Practice Advisor
               </marko-web-link>
             </p>
           </div>


### PR DESCRIPTION
https://southcomm.atlassian.net/browse/DEV-488

Please break out the "Subscribe / Manage Preferences" link into 2 separate links, with each on their own line

Link the "Subscribe" link to: https://endeavor.dragonforms.com/loading.do?omedasite=TPAnewpref

Link the "Manage Preferences" link to: https://endeavor.dragonforms.com/loading.do?omedasite=TPAprefpage

<img width="1165" alt="Screen Shot 2021-02-11 at 3 42 39 PM" src="https://user-images.githubusercontent.com/6343242/107696327-cf548000-6c7f-11eb-890b-a9b40dda1491.png">
