### PR TITLE
Navigation update for DIQ

### DIFF
--- a/sites/dentistryiq.com/config/navigation.js
+++ b/sites/dentistryiq.com/config/navigation.js
@@ -3,7 +3,7 @@ const dragonForms = require('./dragon-forms');
 module.exports = {
   primary: {
     items: [
-      { href: '/covid-19', label: 'COVID-19' },
+      { href: '/personal-wellness', label: 'Personal Wellness' },
       { href: '/dentistry', label: 'Dentistry' },
       { href: '/dental-hygiene', label: 'Dental Hygiene' },
       { href: '/front-office', label: 'Front Office' },
@@ -40,7 +40,7 @@ module.exports = {
     {
       label: 'Topics',
       items: [
-        { href: '/covid-19', label: 'COVID-19' },
+        { href: '/personal-wellness', label: 'Personal Wellness' },
         { href: '/dentistry', label: 'Dentistry' },
         { href: '/dental-hygiene', label: 'Dental Hygiene' },
         { href: '/front-office', label: 'Front Office' },

--- a/sites/dentistryiq.com/server/styles/index.scss
+++ b/sites/dentistryiq.com/server/styles/index.scss
@@ -16,10 +16,10 @@ $theme-newsletter-block-bg-color: $primary;
 $theme-newsletter-block-button-bg-color: #000;
 
 $theme-site-header-breakpoints: (
-  hide-primary: 790px,
+  hide-primary: 905px,
   hide-secondary: 550px,
   small-logo: 696px,
-  small-text-primary: 885px,
+  small-text-primary: 1007px,
   small-text-secondary: 598px
 );
 


### PR DESCRIPTION
Per https://southcomm.atlassian.net/browse/DEV-525

Please replace "COVID-19" in both the main and hamburger navigation with "Personal Wellness"
https://www.dentistryiq.com/personal-wellness

<img width="328" alt="Screen Shot 2021-02-22 at 6 06 28 PM" src="https://user-images.githubusercontent.com/6343242/108782208-2c321f00-7539-11eb-9f72-3917ec1dacd1.png">
<img width="1249" alt="Screen Shot 2021-02-22 at 6 06 20 PM" src="https://user-images.githubusercontent.com/6343242/108782211-2c321f00-7539-11eb-9dc2-e66482fbe19a.png">
