### PR TITLE
Navigation updates for PI

### DIFF
--- a/sites/piprocessinstrumentation.com/config/navigation.js
+++ b/sites/piprocessinstrumentation.com/config/navigation.js
@@ -16,6 +16,7 @@ module.exports = {
       { href: '/subscribe', label: 'Subscribe' },
       { href: '/magazine', label: 'Magazine' },
       { href: '/webinars', label: 'Webinars' },
+      { href: '/white-papers', label: 'White Papers' },
       { href: '/videos', label: 'Videos' },
       { href: '/events', label: 'Events' },
       { href: '/news-reports', label: 'News & Reports' },
@@ -56,6 +57,7 @@ module.exports = {
       items: [
         { href: '/magazine', label: 'Magazine' },
         { href: '/webinars', label: 'Webinars' },
+        { href: '/white-papers', label: 'White Papers' },
         { href: '/videos', label: 'Videos' },
         { href: '/events', label: 'Events' },
         { href: '/news-reports', label: 'News & Reports' },

--- a/sites/piprocessinstrumentation.com/server/styles/index.scss
+++ b/sites/piprocessinstrumentation.com/server/styles/index.scss
@@ -31,11 +31,11 @@ $theme-site-navbar-logo-drop-shadow: "";
 $theme-site-footer-logo-box-shadow: "";
 
 $theme-site-header-breakpoints: (
-  hide-primary: 1005px,
-  hide-secondary: 906px,
-  small-logo: 1015px,
-  small-text-primary: 1152px,
-  small-text-secondary: 1105px
+  hide-primary: 1050px,
+  hide-secondary: 975px,
+  small-logo: 1175px,
+  small-text-primary: 1175px,
+  small-text-secondary: 1175px
 );
 
 @import "../../node_modules/@endeavor-business-media/package-shared/scss/core";


### PR DESCRIPTION
https://southcomm.atlassian.net/browse/DEV-526

- add "White Papers" to both the main nav and hamburger nav, following ‘Webinars,’ on both.

<img width="266" alt="Screen Shot 2021-02-22 at 6 17 19 PM" src="https://user-images.githubusercontent.com/6343242/108782876-66e88700-753a-11eb-9ab1-02e06af3ea44.png">
<img width="1243" alt="Screen Shot 2021-02-22 at 6 17 11 PM" src="https://user-images.githubusercontent.com/6343242/108782878-66e88700-753a-11eb-98a4-e581a8e2b6bb.png">
