### PR TITLE
Set z-index to 50000 in core.scss

### DIFF
--- a/packages/shared/scss/core.scss
+++ b/packages/shared/scss/core.scss
@@ -1,3 +1,5 @@
+$theme-site-header-z-index: 50000;
+
 $theme-site-navbar-logo-height: 45px !default;
 $theme-site-navbar-logo-height-sm: 25px !default;
 


### PR DESCRIPTION
Reduced the z-index to prevent overlaying the welcome ad.  The default value in @base-cms is 500000