### PR TITLE
Set sponsored native-x placement on home block

### DIFF
--- a/sites/officer.com/config/native-x.js
+++ b/sites/officer.com/config/native-x.js
@@ -20,6 +20,9 @@ config
   ])
   .setAliasPlacements('command-hq', [
     { name: 'default', id: '5b5758cf07cd7000019c5fbf' },
+  ])
+  .setAliasPlacements('home', [
+    { name: 'sponsored', id: '60a547de46b8da0001e1280c' },
   ]);
 
 module.exports = config;

--- a/sites/officer.com/server/templates/index.marko
+++ b/sites/officer.com/server/templates/index.marko
@@ -43,7 +43,7 @@ $ const adSlots = ({ aliases }) => ({
               <shared-gam-display-ad id="gpt-ad-ms" />
             </@body>
           </@list>
-          <@native-x enabled=false />
+          <@native-x index=3 name="sponsored" />
         </shared-website-section-list-block>
       </div>
     </div>


### PR DESCRIPTION
Custom native-x placement called “Sponsored” to be used on the “Sponsored” homepage block of officer.com.  Related Topic in Native-X using this placement: https://ebm.native-x.io/app/topic/60a547bbc11aa7000153c0be

Jira request: https://southcomm.atlassian.net/browse/DEV-716

<img width="1158" alt="Screen Shot 2021-05-19 at 1 35 23 PM" src="https://user-images.githubusercontent.com/12496550/118867195-6ac14680-b8a8-11eb-8352-dff91c523b8f.png">


<img width="1678" alt="Screen Shot 2021-05-19 at 1 45 21 PM" src="https://user-images.githubusercontent.com/12496550/118867272-81679d80-b8a8-11eb-9d2c-e371c31176fe.png">
